### PR TITLE
Add delay before TAP interface is fully up and running.

### DIFF
--- a/IPCode.c
+++ b/IPCode.c
@@ -4539,6 +4539,45 @@ void OpenTAP()
 		return;
 	}
 
+	/*
+	 * After some research I found that on most of my
+	 * systems, including Raspberry Pi IV, a slight delay
+	 * is needed before considering the TAP device
+	 * up and running. Otherwise the interface structures
+	 * do not initialise properly and later in the code
+	 * around the line 4700 when we initialise our ARP
+	 * structure:
+	 *
+	 * memcpy(Arp->HWADDR, xbuffer.ifr_hwaddr.sa_data, 6);
+	 *
+	 * the MAC address is getting filled in with random
+	 * value which makes the communication via our TAP
+	 * device using the configured IPADDR virtually
+	 * impossible.
+	 *
+	 */
+	Debugprintf("Waiting for the TAP to become UP and RUNNING");
+	for (int i=10; i>0; i--)
+	{
+		Sleep(10);
+
+		if ((err = ioctl(sockfd, SIOCGIFFLAGS, &ifr)) < 0)
+		{
+			perror("SIOCGIFFLAGS");
+			return;
+		}
+
+		if((ifr.ifr_flags & IFF_UP) && (ifr.ifr_flags & IFF_RUNNING))
+		{
+			Debugprintf("TAP is UP and RUNNING");
+			break;
+		} else if (i == 0)
+		{
+			Debugprintf("TAP is still not UP and RUNNING");
+			return;
+		}
+	}
+
 	printf("TAP brought up\n");
 
 	// Set MTU to 256


### PR DESCRIPTION
This piece of code is to make sure the TAP resources are fully allocated and it is at UP and RUNNING state.
I found that if we proceed without waiting, the ARP entry for local IPADDR is most likely be filled with random value which makes communication with that IP impossible.