### PR TITLE
fix build error on FreeBSD

### DIFF
--- a/IPCode.c
+++ b/IPCode.c
@@ -100,6 +100,9 @@ TODo	?Multiple Adapters
 #ifdef WIN32
 int pcap_sendpacket(pcap_t *p, u_char *buf, int size);
 #else
+ #ifndef PCAP_API
+  #define PCAP_API extern
+ #endif
  PCAP_API int pcap_sendpacket(pcap_t *, const u_char *, int);
 #endif
 

--- a/LinBPQ.c
+++ b/LinBPQ.c
@@ -913,7 +913,7 @@ int main(int argc, char * argv[])
 
 	Debugprintf("G8BPQ AX25 Packet Switch System Version %s %s", TextVerstring, Datestring);
 
-#ifndef MACBPQ
+#if !(defined(MACBPQ) || defined(FREEBSD))
 	_MYTIMEZONE = _timezone;
 #endif
 

--- a/TNCEmulators.c
+++ b/TNCEmulators.c
@@ -241,8 +241,14 @@ typedef struct _SERIAL_STATUS {
 
 #ifndef WIN32
 
-#ifdef MACBPQ
+#if defined(MACBPQ)
 #include <util.h>
+#elif defined(FREEBSD)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+#include <libutil.h>
+#else
+#include <util.h>
+#endif
 #endif
 
 extern int posix_openpt (int __oflag);
@@ -262,7 +268,7 @@ HANDLE LinuxOpenPTY(char * Name)
 	u_long param=1;
 	struct termios term;
 
-#ifdef MACBPQ
+#if defined(MACBPQ) || defined(FREEBSD)
 
 	// Create a pty pair
 	

--- a/asmstrucs.h
+++ b/asmstrucs.h
@@ -1087,7 +1087,11 @@ struct SEM
 	int	Gets;
 	int Rels;
 	DWORD SemProcessID;
+#ifdef WIN32
 	DWORD SemThreadID;
+#else
+	pthread_t SemThreadID;
+#endif
 	int Line;		// caller file and line
 	char File[MAX_PATH];
 };

--- a/linether.c
+++ b/linether.c
@@ -22,7 +22,7 @@ along with LinBPQ/BPQ32.  If not, see http://www.gnu.org/licenses
 
 // Normally uses a Raw socket, but that can't send to other apps on same machine.
 // so can use a TAP device instead (or maybe as well??)
-#ifndef MACBPQ
+#if !(defined(MACBPQ) || defined(FREEBSD))
 
 #include <stdio.h>
 

--- a/makefile_bsd
+++ b/makefile_bsd
@@ -1,0 +1,39 @@
+#	LinBPQ Makefile
+
+#	To exclude i2c support run make noi2c
+
+OBJS = pngwtran.o pngrtran.o pngset.o pngrio.o pngwio.o pngtrans.o pngrutil.o pngwutil.o\
+ pngread.o pngwrite.o png.o pngerror.o pngget.o pngmem.o APRSIconData.o AISCommon.o\
+ upnp.o APRSStdPages.o HSMODEM.o WinRPR.o KISSHF.o TNCEmulators.o bpqhdlc.o SerialPort.o\
+ adif.o WebMail.o utf8Routines.o VARA.o LzFind.o Alloc.o LzmaDec.o LzmaEnc.o LzmaLib.o \
+ Multicast.o ARDOP.o IPCode.o FLDigi.o linether.o CMSAuth.o APRSCode.o BPQtoAGW.o KAMPactor.o\
+ AEAPactor.o HALDriver.o MULTIPSK.o BBSHTMLConfig.o ChatHTMLConfig.o BBSUtilities.o bpqaxip.o\
+ BPQINP3.o BPQNRR.o cMain.o Cmd.o CommonCode.o HTMLCommonCode.o compatbits.o config.o datadefs.o \
+ FBBRoutines.o HFCommon.o Housekeeping.o HTTPcode.o kiss.o L2Code.o L3Code.o L4Code.o lzhuf32.o \
+ MailCommands.o MailDataDefs.o LinBPQ.o MailRouting.o MailTCP.o MBLRoutines.o md5.o Moncode.o \
+ NNTPRoutines.o RigControl.o TelnetV6.o WINMOR.o TNCCode.o UZ7HODrv.o WPRoutines.o \
+ SCSTrackeMulti.o SCSPactor.o SCSTracker.o HanksRT.o  UIRoutines.o AGWAPI.o AGWMoncode.o \
+ DRATS.o FreeDATA.o base64.o Events.o nodeapi.o mailapi.o mqtt.o RHP.o
+
+# Configuration:
+
+CC = cc
+		                       
+all: CFLAGS = -DLINBPQ -DFREEBSD -DNOMQTT -MMD -g -fcommon -I/usr/local/include
+all: linbpq
+
+
+noi2c: CFLAGS = -DLINBPQ -MMD -DNOI2C -g
+noi2c: linbpq
+
+	
+linbpq: $(OBJS)
+	cc $(OBJS) -L/usr/local/lib -Xlinker  -lminiupnpc -liconv  -lm -lz -lpthread -lconfig -lpcap -lexecinfo -o linbpq
+	cp linbpq ../linbpq/linbpq.new		
+
+-include *.d
+
+clean :
+	rm -f *.d
+	rm -f linbpq $(OBJS)
+

--- a/makefile_bsd
+++ b/makefile_bsd
@@ -28,7 +28,7 @@ noi2c: linbpq
 
 	
 linbpq: $(OBJS)
-	cc $(OBJS) -L/usr/local/lib -Xlinker  -lminiupnpc -liconv  -lm -lz -lpthread -lconfig -lpcap -lexecinfo -o linbpq
+	cc $(OBJS) -L/usr/local/lib -Xlinker  -lminiupnpc -liconv  -lm -lz -lpthread -lconfig -lpcap -lexecinfo -lutil -o linbpq
 	cp linbpq ../linbpq/linbpq.new		
 
 -include *.d

--- a/makefile_bsd
+++ b/makefile_bsd
@@ -18,8 +18,17 @@ OBJS = pngwtran.o pngrtran.o pngset.o pngrio.o pngwio.o pngtrans.o pngrutil.o pn
 # Configuration:
 
 CC = cc
+
+OS_NAME = $(shell uname -s)
+ifeq ($(OS_NAME),NetBSD)
+    EXTRA_CFLAGS = -I/usr/pkg/include
+    EXTRA_LDFLAGS = -L/usr/pkg/lib -lrt
+else
+    EXTRA_CFLAGS = -I/usr/local/include
+    EXTRA_LDFLAGS = -L/usr/local/lib -liconv
+endif
 		                       
-all: CFLAGS = -DLINBPQ -DFREEBSD -DNOMQTT -MMD -g -fcommon -I/usr/local/include
+all: CFLAGS = -DLINBPQ -DFREEBSD -DNOMQTT -MMD -g -fcommon $(EXTRA_CFLAGS)
 all: linbpq
 
 
@@ -28,7 +37,7 @@ noi2c: linbpq
 
 	
 linbpq: $(OBJS)
-	cc $(OBJS) -L/usr/local/lib -Xlinker  -lminiupnpc -liconv  -lm -lz -lpthread -lconfig -lpcap -lexecinfo -lutil -o linbpq
+	cc $(OBJS) $(EXTRA_LDFLAGS) -Xlinker  -lminiupnpc  -lm -lz -lpthread -lconfig -lpcap -lexecinfo -lutil -o linbpq
 	cp linbpq ../linbpq/linbpq.new		
 
 -include *.d

--- a/upnp.c
+++ b/upnp.c
@@ -134,7 +134,7 @@ int upnpInit()
 				return 0;
 			}
 
-#if MINIUPNPC_API_VERSION == 18
+#if MINIUPNPC_API_VERSION >= 18
 			i = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), wanaddr, sizeof(wanaddr));
 #else
 			i = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
@@ -168,7 +168,7 @@ int upnpClose()
 				return 0;
 			}
 
-#if MINIUPNPC_API_VERSION == 18
+#if MINIUPNPC_API_VERSION >= 18
 			i = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), wanaddr, sizeof(wanaddr));
 #else
 			i = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));


### PR DESCRIPTION
I found `#ifdef FREEBSD` in linbpq but some error prevents on building LinBPQ on FreeBSD.
This is the remedy. Needs to fix many warnings, this is future homework.

This also enables LinBPQ for OpenBSD.